### PR TITLE
Fix wild mons table creation

### DIFF
--- a/src/data/wild_encounters.json.txt
+++ b/src/data/wild_encounters.json.txt
@@ -35,7 +35,7 @@ const struct WildPokemon {{ encounter.base_label }}_LandMons[] =
 const struct WildPokemonInfo {{ encounter.base_label }}_LandMonsInfo = { {{encounter.land_mons.encounter_rate}}, {{ encounter.base_label }}_LandMons };
 {% endif %}
 {% if existsIn(encounter, "land_mons_morning") %}
-const struct WildPokemon {{ encounter.base_label }}_LandMons[] =
+const struct WildPokemon {{ encounter.base_label }}_LandMonsMorning[] =
 {
 ## for wild_mon in encounter.land_mons_morning.mons
     { {{ wild_mon.min_level }}, {{ wild_mon.max_level }}, {{ wild_mon.species }} },


### PR DESCRIPTION
## Description
There was a bug that didn't allow you to build new wild mon tables that had Morning Land mons, since they shared same function name in part of the code. That made the wild mon group being both duplicated and undeclared at the same time depending on the function.


## **Discord contact info**
Jaizu#2172