### PR TITLE
Add additional check to CanThrowLastUsedBall

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2656,6 +2656,7 @@ bool32 CanThrowLastUsedBall(void)
 {
     return (!(IsPlayerPartyAndPokemonStorageFull()
 	 || InBattlePyramid()
+     || (IsPlayerPartyAndPokemonStorageFull())
      || (gBattleTypeFlags & BATTLE_TYPE_TRAINER)
      || !CheckBagHasItem(gSaveBlock2Ptr->lastUsedBall, 1)
 	 || (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)));


### PR DESCRIPTION
If the player has both the party and the Pokémon storage full he shouldn't be able to throw any type of Pokéball